### PR TITLE
[ADYEN-553] Add shopper statement parameter to the authorize request interface.

### DIFF
--- a/src/Omnipay/AdyenApi/Message/Payment/Authorise/Request.php
+++ b/src/Omnipay/AdyenApi/Message/Payment/Authorise/Request.php
@@ -251,6 +251,23 @@ class Request extends AbstractPaymentRequest
     }
 
     /**
+     * @return string
+     */
+    public function getShopperStatement()
+    {
+        return $this->getParameter('shopperStatement');
+    }
+    /**
+     * @param string $value
+     *
+     * @return Request
+     */
+    public function setShopperStatement($value)
+    {
+        return $this->setParameter('shopperStatement', $value);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getData()
@@ -389,6 +406,9 @@ class Request extends AbstractPaymentRequest
         }
         if ($this->getShopperInteraction() !== null) {
             $data = $this->appendParameter($data, 'shopperInteraction', $this->getShopperInteraction());
+        }
+        if ($this->getShopperStatement() !== null) {
+            $data = $this->appendParameter($data, 'shopperStatement', $this->getShopperStatement());
         }
 
         return $data;

--- a/src/Omnipay/AdyenApi/Tests/Message/Payment/Authorise/RequestTest.php
+++ b/src/Omnipay/AdyenApi/Tests/Message/Payment/Authorise/RequestTest.php
@@ -155,6 +155,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             'shopperReference' => 'ShopperReference',
             'shopperEmail' => 'ShopperEmail',
             'shopperInteraction' => 'ShopperInteraction',
+            'shopperStatement' => 'A shopper statement',
         );
 
         $this->request->initialize($data);
@@ -173,6 +174,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 'shopperReference' => $data['shopperReference'],
                 'shopperEmail' => $data['shopperEmail'],
                 'shopperInteraction' => $data['shopperInteraction'],
+                'shopperStatement' => $data['shopperStatement'],
             ),
             $this->request->getData()
         );
@@ -196,6 +198,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             'selectedRecurringDetailReference' => 'SelectedRecurringDetailReference',
             'shopperEmail' => 'ShopperEmail',
             'shopperInteraction' => 'ShopperInteraction',
+            'shopperStatement' => 'A shopper statement',
         );
 
         $this->request->initialize($data);
@@ -223,6 +226,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 'selectedRecurringDetailReference' => $data['selectedRecurringDetailReference'],
                 'shopperEmail' => $data['shopperEmail'],
                 'shopperInteraction' => $data['shopperInteraction'],
+                'shopperStatement' => $data['shopperStatement'],
             ),
             $this->request->getData()
         );
@@ -358,6 +362,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             'SHOPPER_EMAIL' => array('shopperEmail', 'MyShopperEmail'),
             'SELECTED_RECURRING_DETAIL_REFERENCE' => array('selectedRecurringDetailReference', 'MySelectedRecurringDetailReference'),
             'SHOPPER_INTERACTION' => array('shopperInteraction', 'MyShopperInteraction'),
+            'SHOPPER_STATEMENT' => array('shopperStatement', 'A shopper statement'),
         );
     }
 }


### PR DESCRIPTION
According to the Adyen documentation https://docs.adyen.com/developers/api-reference/payments-api#paymentrequest

for the refund request the shopperReference parameter in not available, i guess it will probably take the shopperStatement of the authorization operation bound to the actual refund api call. (As you can see from Adyen API of refund endpoint https://docs.adyen.com/developers/payment-modifications#refund)

I'm going to release this only into the 2.* version of this library since in the 3.* (which is the master branch) it is already present (as you can see here https://github.com/lafourchette/omnipay-adyen/blob/master/src/Omnipay/AdyenApi/Message/Payment/Authorise/Request.php#L404)